### PR TITLE
Fix miri issues

### DIFF
--- a/src/bits/bit_dst.rs
+++ b/src/bits/bit_dst.rs
@@ -47,6 +47,8 @@ impl BitDst for Vec<u8> {
         debug_assert!(n_bytes <= mem::size_of::<usize>());
         let index = self.len();
         assert!(mem::size_of::<usize>() <= self.capacity() - self.len());
+        // We bind to a variable to ensure the pointer remains valid for the copy operation,
+        // preventing a Miri error where the temporary byte array is dropped too early.
         let src_bytes = bytes.to_le_bytes();
         let src = src_bytes.as_ptr();
         let dst = self.as_mut_ptr().add(index);

--- a/src/bits/bit_dst.rs
+++ b/src/bits/bit_dst.rs
@@ -47,7 +47,8 @@ impl BitDst for Vec<u8> {
         debug_assert!(n_bytes <= mem::size_of::<usize>());
         let index = self.len();
         assert!(mem::size_of::<usize>() <= self.capacity() - self.len());
-        let src = bytes.to_le_bytes().as_ptr();
+        let src_bytes = bytes.to_le_bytes();
+        let src = src_bytes.as_ptr();
         let dst = self.as_mut_ptr().add(index);
         ptr::copy_nonoverlapping(src, dst, mem::size_of::<usize>());
         self.set_len(index + n_bytes);

--- a/src/ring/object.rs
+++ b/src/ring/object.rs
@@ -16,6 +16,13 @@ pub const OVERMATCH_LEN: usize = 5 * mem::size_of::<usize>();
 
 pub struct Ring<'a, T>(*mut u8, PhantomData<T>, PhantomData<&'a mut ()>);
 
+impl<'a, T> Ring<'a, T> {
+    pub fn full_ptr(&self) -> *mut u8 {
+        self.0
+    }
+}
+
+
 // Implementation notes:
 //
 // Hybrid ring buffer.

--- a/src/ring/object.rs
+++ b/src/ring/object.rs
@@ -16,12 +16,16 @@ pub const OVERMATCH_LEN: usize = 5 * mem::size_of::<usize>();
 
 pub struct Ring<'a, T>(*mut u8, PhantomData<T>, PhantomData<&'a mut ()>);
 
-impl<'a, T> Ring<'a, T> {
-    pub fn full_ptr(&self) -> *mut u8 {
-        self.0
-    }
-}
-
+ impl<'a, T> Ring<'a, T> {
++    /// Returns a raw pointer to the entire ring buffer.
++    ///
++    /// Using the full pointer ensures that pointer provenance is maintained over
++    /// the entire buffer range, avoiding Miri errors when wide-copy operations
++    /// read beyond the nominal data range.
+     pub fn full_ptr(&self) -> *mut u8 {
+         self.0
+     }
+ }
 
 // Implementation notes:
 //

--- a/src/ring/ring_view.rs
+++ b/src/ring/ring_view.rs
@@ -25,6 +25,7 @@ impl<'a, T: RingType> RingView<'a, T> {
     pub fn new(ring: &'a Ring<T>, head: Idx, tail: Idx) -> Self {
         debug_assert!((tail - head) as u32 <= T::RING_SIZE);
         Self {
+            // We use the full pointer to maintain provenance over the entire ring buffer.
             ring_ptr: ring.full_ptr(),
             head,
             tail,

--- a/src/ring/ring_view.rs
+++ b/src/ring/ring_view.rs
@@ -25,7 +25,7 @@ impl<'a, T: RingType> RingView<'a, T> {
     pub fn new(ring: &'a Ring<T>, head: Idx, tail: Idx) -> Self {
         debug_assert!((tail - head) as u32 <= T::RING_SIZE);
         Self {
-            ring_ptr: ring.as_ptr(),
+            ring_ptr: ring.full_ptr(),
             head,
             tail,
             _phantom: (PhantomData::default(), PhantomData::default()),

--- a/src/types/short_bytes.rs
+++ b/src/types/short_bytes.rs
@@ -7,7 +7,7 @@ use std::slice;
 
 /// Byte wrapper with a a maximum length of `T::SHORT_LIMIT` and at least `W::WIDTH` slack bytes.
 #[derive(Copy, Clone)]
-pub struct ShortBytes<'a, T, W>(&'a [u8], PhantomData<T>, PhantomData<W>);
+pub struct ShortBytes<'a, T, W>(*const u8, usize, PhantomData<T>, PhantomData<W>, PhantomData<&'a ()>);
 
 impl<'a, T: ShortLimit, W: Width> ShortBytes<'a, T, W> {
     #[allow(dead_code)]
@@ -31,7 +31,7 @@ impl<'a, T: ShortLimit, W: Width> ShortBytes<'a, T, W> {
     #[inline(always)]
     pub unsafe fn from_raw_parts(ptr: *const u8, len: usize) -> Self {
         debug_assert!(len <= T::SHORT_LIMIT as usize);
-        Self(slice::from_raw_parts(ptr, len), PhantomData::default(), PhantomData::default())
+        Self(ptr, len, PhantomData::default(), PhantomData::default(), PhantomData::default())
     }
 }
 
@@ -39,7 +39,7 @@ impl<'a, T, W: Width> CopyLong for ShortBytes<'a, T, W> {
     #[inline(always)]
     unsafe fn copy_long_raw(&self, dst: *mut u8, len: usize) {
         debug_assert!(len <= self.len());
-        CopyTypeLong::wide_copy::<W>(self.0.as_ptr(), dst, len);
+        CopyTypeLong::wide_copy::<W>(self.0, dst, len);
     }
 }
 
@@ -47,14 +47,14 @@ impl<'a, T: ShortLimit, W: Width> CopyShort for ShortBytes<'a, T, W> {
     #[inline(always)]
     unsafe fn copy_short_raw<V: CopyType>(&self, dst: *mut u8, len: usize) {
         debug_assert!(len <= self.len());
-        V::wide_copy::<W>(self.0.as_ptr(), dst, len);
+        V::wide_copy::<W>(self.0, dst, len);
     }
 }
 
 impl<'a, T, W> Len for ShortBytes<'a, T, W> {
     #[inline(always)]
     fn len(&self) -> usize {
-        self.0.len()
+        self.1
     }
 }
 
@@ -66,7 +66,8 @@ impl<'a, T, W> Skip for ShortBytes<'a, T, W> {
     #[inline(always)]
     unsafe fn skip_unchecked(&mut self, len: usize) {
         debug_assert!(len <= self.len());
-        self.0 = self.0.get_unchecked(len..);
+        self.0 = self.0.add(len);
+        self.1 -= len;
     }
 }
 
@@ -75,6 +76,6 @@ impl<'a, T, W> Deref for ShortBytes<'a, T, W> {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.0
+        unsafe { slice::from_raw_parts(self.0, self.1) }
     }
 }

--- a/src/types/short_bytes.rs
+++ b/src/types/short_bytes.rs
@@ -6,6 +6,10 @@ use std::ops::Deref;
 use std::slice;
 
 /// Byte wrapper with a a maximum length of `T::SHORT_LIMIT` and at least `W::WIDTH` slack bytes.
+///
+/// We use a raw pointer and length instead of a slice to maintain pointer provenance
+/// over the entire required memory range (including slack). This avoids Miri errors
+/// when `wide_copy` reads beyond the nominal length of the data.
 #[derive(Copy, Clone)]
 pub struct ShortBytes<'a, T, W>(*const u8, usize, PhantomData<T>, PhantomData<W>, PhantomData<&'a ()>);
 


### PR DESCRIPTION
Miri detected 3 issues in the unsafe rust code used in this crate:
 - Use of Dangling Pointer to Temporary Array in src/bits/bit_dst.rs which is fixed by extending the lifetime of of the temporary by binding it to a variable
 - Out-of-Bounds Access due to Narrowed Pointer Provenance in src/ring/ring_view.rs which is fixed by adding the `full_ptr` method to `Ring` which is used to initialize `RingView`
 - Out-of-Bounds Access due to Narrowed Pointer Provenance in ShortBytes in src/types/short_bytes.rs which is fixed by updating ShortBytes to store the raw ptr and length separately, ensuring the pointer maintains provenance over the entire required memory range (including slack).
